### PR TITLE
Cli improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "futures",
  "futures-util",
  "git-pack",
+ "git2",
  "russh",
  "russh-keys",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,30 +316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "clap",
- "ed25519-dalek",
- "flate2",
- "futures",
- "futures-util",
- "git-pack",
- "russh",
- "russh-keys",
- "thiserror",
- "thoenix-http",
- "thoenix-ssh",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +1905,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thoenix"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "clap",
+ "ed25519-dalek",
+ "flate2",
+ "futures",
+ "futures-util",
+ "git-pack",
+ "russh",
+ "russh-keys",
+ "thiserror",
+ "thoenix-http",
+ "thoenix-ssh",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,12 +279,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "clap",
  "ed25519-dalek",
  "flate2",
  "futures",
@@ -432,6 +470,27 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -797,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +869,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -935,6 +1006,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1093,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1087,7 +1186,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1147,7 +1246,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1192,6 +1291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,7 +1322,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1315,6 +1420,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1538,6 +1667,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1900,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1883,7 +2041,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2160,6 +2318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2337,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Any `.nix` files included will be built into JSON using terranix and included in
 
 # getting started
 
+## quickstart
+
 You may use one of the templates to get started:
 
 Initialize in the current directory:
@@ -18,14 +20,17 @@ Or, create a new one
 
 `nix flake new --template github:justinrubek/thoenix#flake-module ./terraform-project`
 
+- The `flake-module` template exposes a [flake-parts](https://github.com/hercules-ci/flake-parts) module that can be used to expose your configuration as flake outputs.
+- The `lib` example allows for more manual control over the final output values.
 
-The `flake-module` template exposes a [flake-parts](https://github.com/hercules-ci/flake-parts) module that can be used to expose your configuration as flake outputs.
-The `lib` example allows for more manual control over the final output values.
 
-Each template comes with a helper script, `tnix`, which can be used to run terraform commands from within individual configurations.
-The arguments `tnix` is called with are passed to the terraform cli with the exception of the first one which specifies which configuration to use.
-To initialize terraform after using the template you would run `tnix core init` from the default devShell.
-The value `core` refers to the name of the terraform configuration to use-- the subdirectory of the terraform configuration directory given to thoenix.
+## other info
+
+The flake's `cli` package includes a `terraform` subcommand which builds the terranix configuration and invoke `terraform`.
+
+- The first argument is the configuration's name, which corresponds a subdirectory in the repo's `terraform/configurations` directory. Terraform will be invoked within that directory.
+- All other arguments are passed through to terraform. You may need to escape some, i.e. `thoenix terraform apps init -- -upgrade`
+- This assumes that the configuration name is a flake output package: `.#terraformConfiguration/{name}`
 
 # why use this
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,3 +25,4 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 thoenix-ssh = { path = "../ssh" }
 thoenix-http = { path = "../http" }
+git2 = "0.16.1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "thoenix"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ git-pack = "0.30.1"
 russh = "0.36.0"
 russh-keys = "0.24.0"
 thiserror = "1.0.38"
-# clap = { version = "4.0.19", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 # reqwest = { version = "0.11.12", features = ["rustls-tls"] }
 # serde = { version = "1", features = ["derive"] }
 # serde_json = "1.0.87"

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,0 +1,39 @@
+#[derive(clap::Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Args {
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub(crate) enum Commands {
+    /// commands for running the scheduling server
+    Server(Server),
+    /// commands for interacting with terraform
+    Terraform(Terraform),
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct Server {
+    #[clap(subcommand)]
+    pub command: ServerCommands,
+
+    /// the directory to store persistent data
+    #[arg(long, short)]
+    pub data_dir: std::path::PathBuf,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub(crate) enum ServerCommands {
+    /// start the server in http mode
+    Http,
+    /// start the server in ssh mode
+    Ssh,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct Terraform {
+    // capture all args passed in to a single string
+    #[arg()]
+    pub args: Vec<String>,
+}

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -7,9 +7,11 @@ pub(crate) struct Args {
 
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Commands {
-    /// commands for running the server
+    /// commands for running the git server
     Server(Server),
-    /// commands for interacting with terraform
+    /// commands for interacting with terraform.
+    ///
+    /// terraform will be invoked in the specified workspace's directory with the remaining arguments passed as-is,
     Terraform(Terraform),
 }
 
@@ -33,7 +35,10 @@ pub(crate) enum ServerCommands {
 
 #[derive(clap::Args, Debug)]
 pub(crate) struct Terraform {
-    // capture all args passed in to a single string
     #[arg()]
+    /// the name of the terraform configuration to use
+    pub configuration_name: String,
+    #[arg()]
+    /// the arguments to pass to terraform
     pub args: Vec<String>,
 }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -7,7 +7,7 @@ pub(crate) struct Args {
 
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Commands {
-    /// commands for running the scheduling server
+    /// commands for running the server
     Server(Server),
     /// commands for interacting with terraform
     Terraform(Terraform),

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -15,14 +15,13 @@ pub enum AppError {
     #[error(transparent)]
     GitPackDataInit(#[from] git_pack::data::init::Error),
 
-    // Application specific errors
-    #[error("no data directory specified")]
-    NoDataDir,
-
     #[error(transparent)]
     SshError(#[from] thoenix_ssh::error::Error),
     #[error(transparent)]
     HttpError(#[from] thoenix_http::error::Error),
+
+    #[error("invalid args: {0}")]
+    InvalidArgs(String),
 }
 
 pub type AppResult<T> = Result<T, AppError>;

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -22,6 +22,8 @@ pub enum AppError {
 
     #[error("invalid args: {0}")]
     InvalidArgs(String),
+    #[error("terraform error: {0}")]
+    TerraformError(i32),
 }
 
 pub type AppResult<T> = Result<T, AppError>;

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -14,16 +14,20 @@ pub enum AppError {
     Ed25519(#[from] ed25519_dalek::ed25519::Error),
     #[error(transparent)]
     GitPackDataInit(#[from] git_pack::data::init::Error),
+    #[error(transparent)]
+    Utf8(#[from] std::str::Utf8Error),
 
     #[error(transparent)]
     SshError(#[from] thoenix_ssh::error::Error),
     #[error(transparent)]
     HttpError(#[from] thoenix_http::error::Error),
 
-    #[error("invalid args: {0}")]
-    InvalidArgs(String),
     #[error("terraform error: {0}")]
     TerraformError(i32),
+    #[error("git repo error: {0}")]
+    GitRepo(#[from] git2::Error),
+    #[error("failed to execute nix: {0}")]
+    Nix(i32),
 }
 
 pub type AppResult<T> = Result<T, AppError>;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use tracing::info;
 
 mod commands;
 mod error;
@@ -29,9 +28,7 @@ async fn main() -> AppResult<()> {
         Commands::Terraform(terraform) => {
             let mut terraform = terraform.spawn_command().await?;
             let status = terraform.wait().await?;
-            info!(?status);
 
-            // If the process exited with a non-zero exit code, return an error
             if !status.success() {
                 let code = status.code().expect("no exit code");
                 return Err(error::AppError::TerraformError(code));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,12 +32,27 @@ async fn main() -> AppResult<()> {
                 .ok_or_else(|| error::AppError::InvalidArgs("no terraform args".to_string()))?;
 
             // read all args and print them
-            info!(?workspace, ?args);
+            info!(?workspace, ?args, "spawning terraform command");
 
             // Call the terraform executable with the provided args
             // The workspace will determine the directory to run terraform in (using the -chdir flag)
-            todo!()
+            // The args will be passed to terraform as-is
+            let mut terraform = tokio::process::Command::new("terraform")
+                .arg(format!("-chdir={workspace}"))
+                .args(args)
+                .spawn()?;
+
+            // From here, let the process take over. Display the output from it, both stdout and stderr
+            let status = terraform.wait().await?;
+            info!(?status);
+
+            // If the process exited with a non-zero exit code, return an error
+            if !status.success() {
+                let code = status.code();
+                return Err(error::AppError::TerraformError(code.expect("no exit code")));
+            }
         }
     }
+
     Ok(())
 }

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -13,7 +13,6 @@ impl Server {
     }
 
     /// experimental ssh server, functionality is not complete
-    #[allow(dead_code)]
     pub(crate) async fn ssh_server(self) -> AppResult<()> {
         let data_dir = self.data_dir.to_str().unwrap();
 

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -1,0 +1,63 @@
+use crate::error::AppResult;
+use russh_keys::PublicKeyBase64;
+use std::{path::PathBuf, sync::Arc};
+use tracing::info;
+
+pub(crate) struct Server {
+    data_dir: PathBuf,
+}
+
+impl Server {
+    pub(crate) fn new(data_dir: PathBuf) -> Self {
+        Self { data_dir }
+    }
+
+    /// experimental ssh server, functionality is not complete
+    #[allow(dead_code)]
+    pub(crate) async fn ssh_server(self) -> AppResult<()> {
+        let data_dir = self.data_dir.to_str().unwrap();
+
+        let keys = thoenix_ssh::util::get_or_generate_keypair(data_dir).await?;
+
+        let config = russh::server::Config {
+            auth_rejection_time: std::time::Duration::from_secs(3),
+            auth_rejection_time_initial: Some(std::time::Duration::from_secs(0)),
+            keys: vec![keys],
+            connection_timeout: Some(std::time::Duration::from_secs(30)),
+            ..Default::default()
+        };
+
+        let server = thoenix_ssh::handler::SshServer {
+            data_dir: PathBuf::from(data_dir),
+        };
+
+        let address = (
+            "127.0.0.0",
+            std::env::var("PORT")
+                .unwrap_or_else(|_| "2222".to_string())
+                .parse()
+                .unwrap(),
+        );
+
+        let public_key = config.keys[0].public_key_base64();
+        info!(%public_key);
+
+        info!(?address, "starting server");
+        russh::server::run(Arc::new(config), address, server).await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn http_server(self) -> AppResult<()> {
+        let server = thoenix_http::Server::new(self.data_dir);
+
+        let port = std::env::var("PORT")
+            .unwrap_or_else(|_| "3000".to_string())
+            .parse()
+            .unwrap();
+
+        server.run(port).await?;
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/terraform.rs
+++ b/crates/cli/src/terraform.rs
@@ -1,0 +1,72 @@
+use crate::AppResult;
+use std::{os::unix::prelude::PermissionsExt, path::PathBuf};
+use tracing::{debug, error, info};
+
+impl crate::commands::Terraform {
+    /// Calls terraform's cli, but with some extra preparation to build the configuration
+    /// The configuration's derivation is built using `nix eval --raw .#terraformConfiguration/{configuration_name}`.
+    /// The configuration's `config.tf.json` file is copied to the configuration directory in the local repository.
+    /// Finally the terraform cli is called with the given arguments. It will detect the
+    /// `config.tf.json` file in addition to any HCL files in the configuration directory.
+    pub async fn spawn_command(self) -> AppResult<tokio::process::Child> {
+        info!(?self.args, ?self.configuration_name);
+
+        info!("building terraform configuration");
+        let nix_eval = tokio::process::Command::new("nix")
+            .arg("eval")
+            .arg("--raw")
+            .arg(format!(
+                ".#terraformConfiguration/{}",
+                self.configuration_name
+            ))
+            .output()
+            .await?;
+
+        if !nix_eval.status.success() {
+            // TODO: better detect the error that is happening. It is likely that the configuration
+            // does not exist in the nix flake if it fails here
+            let err = std::str::from_utf8(&nix_eval.stderr)?;
+            error!("{:?}", err);
+            return Err(crate::error::AppError::Nix(
+                nix_eval.status.code().unwrap_or(1),
+            ));
+        }
+
+        let derivation_path = std::str::from_utf8(&nix_eval.stdout)?.trim();
+        debug!(?derivation_path, "built terraform configuration");
+        let generated_configuration_path = PathBuf::from(derivation_path).join("config.tf.json");
+
+        let repo = git2::Repository::discover(".")?;
+        let repo_path = repo.path().parent().unwrap();
+        // TODO: Support other terraform configuration directories?
+        let configuration_directory = repo_path
+            .join("terraform")
+            .join("configurations")
+            .join(self.configuration_name);
+        let destination = configuration_directory.join("config.tf.json");
+
+        // Only attempt to copy the nix generated configuration if it exists
+        if generated_configuration_path.exists() {
+            info!(
+                "copying generated config file {:?} -> {:?}",
+                generated_configuration_path, destination
+            );
+            tokio::fs::copy(&generated_configuration_path, &destination).await?;
+
+            // mark the destination file as writeable for the current user as it came from the read only nix store
+            let mut perms = tokio::fs::metadata(&destination).await?.permissions();
+            perms.set_mode(0o644);
+            info!("-> setting permissions to {:?}", perms);
+            tokio::fs::set_permissions(&destination, perms).await?;
+        }
+
+        // Call the terraform executable with the provided args
+        info!(?configuration_directory, ?self.args, "invoking terraform");
+        let terraform = tokio::process::Command::new("terraform")
+            .arg(format!("-chdir={}", configuration_directory.display()))
+            .args(self.args)
+            .spawn()?;
+
+        Ok(terraform)
+    }
+}

--- a/examples/lib/flake-parts/terraformConfiguration.nix
+++ b/examples/lib/flake-parts/terraformConfiguration.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: {
-  imports = [ ];
+  imports = [];
 
   perSystem = {
     self',
@@ -33,10 +33,10 @@
     # the output of `buildTerraformConfigurations` is a set, so we can just use attrNames
     terraformConfigurationNames = builtins.attrNames finalConfigurations;
 
-    # rename all values from finalConfigurations to be prefixed with `terraformConfiguration_`
+    # rename all values from finalConfigurations to be prefixed with `terraformConfiguration/`
     # this allows them to be specified in the `packages` flake output
     terraformConfigurationOutput = let
-      prefix = "terraformConfiguration_";
+      prefix = "terraformConfiguration/";
       reducer = l: r: l // {"${prefix}${r}" = finalConfigurations.${r};};
     in
       builtins.foldl' reducer {} terraformConfigurationNames;

--- a/flake-parts/cargo.nix
+++ b/flake-parts/cargo.nix
@@ -88,9 +88,9 @@
     };
 
     cli-package = craneLib.buildPackage ({
-        pname = "cli";
+        pname = "thoenix";
         cargoArtifacts = deps-only;
-        cargoExtraArgs = "--bin cli";
+        cargoExtraArgs = "--bin thoenix";
       }
       // common-build-args);
   in rec {
@@ -109,7 +109,7 @@
     apps = {
       cli = {
         type = "app";
-        program = "${self.packages.${system}.cli}/bin/cli";
+        program = "${self.packages.${system}.cli}/bin/thoenix";
       };
       default = apps.cli;
     };

--- a/flake-parts/cargo.nix
+++ b/flake-parts/cargo.nix
@@ -19,6 +19,7 @@
       rustfmt
       cargo-nextest
       # misc
+      pkgs.terraform
     ];
 
     extraNativeBuildInputs = [


### PR DESCRIPTION
Closes #7 

- Adds clap for commands
- Commands for starting `http` and `ssh` servers: `thoenix server --data-dir ./repos http`
- Command to pass to terraform: `thoenix terraform apps apply`