### PR TITLE
Call `nix build` instead of `nix eval` when evaluating terraform configurations

### DIFF
--- a/crates/cli/src/terraform.rs
+++ b/crates/cli/src/terraform.rs
@@ -13,8 +13,9 @@ impl crate::commands::Terraform {
 
         info!("building terraform configuration");
         let nix_eval = tokio::process::Command::new("nix")
-            .arg("eval")
-            .arg("--raw")
+            .arg("build")
+            .arg("--no-link")
+            .arg("--print-out-paths")
             .arg(format!(
                 ".#terraformConfiguration/{}",
                 self.configuration_name


### PR DESCRIPTION
When using `nix eval`, it seemed that the latest built configuration would be used. If changes were made to the local repository they weren't reflected in plan/apply. Switching to `nix build` ensures that any uncommitted changes are included in the plan