### PR TITLE
refactor: default to opentofu

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -41,4 +41,7 @@ pub(crate) struct Terraform {
     #[arg()]
     /// the arguments to pass to terraform
     pub args: Vec<String>,
+    /// the command to run when invoking terraform
+    #[arg(long, short, default_value = "tofu")]
+    pub command: String,
 }

--- a/crates/cli/src/terraform.rs
+++ b/crates/cli/src/terraform.rs
@@ -67,7 +67,7 @@ impl crate::commands::Terraform {
 
         // Call the terraform executable with the provided args
         info!(?configuration_directory, ?self.args, "invoking terraform");
-        let terraform = tokio::process::Command::new("terraform")
+        let terraform = tokio::process::Command::new(&self.command)
             .arg(format!("-chdir={}", configuration_directory.display()))
             .args(self.args)
             .spawn()?;

--- a/flake-parts/shells.nix
+++ b/flake-parts/shells.nix
@@ -21,7 +21,7 @@
       # formatting
       self'.packages.treefmt
       # misc
-      pkgs.terraform
+      pkgs.opentofu
     ];
   in {
     devShells = {

--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1696193975,
-        "narHash": "sha256-mnQjUcYgp9Guu3RNVAB2Srr1TqKcPpRXmJf4LJk6KRY=",
+        "lastModified": 1701436327,
+        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdd898f8f79e8d2f99ed2ab6b3751811ef683242",
+        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Terraform has switched to an unfree license and is no longer provided by the devShell. Thoenix now executes `tofu` by default. The command can be specified with the `--command`, `-c` flag. Thoenix's interface remains the same but breakage will be caused wherever this is used that does not have the `tofu` command available.