### PR TITLE
fix(flake-module): use `importApply` to instantiate module

### DIFF
--- a/flake-parts/flake-module.nix
+++ b/flake-parts/flake-module.nix
@@ -1,4 +1,4 @@
-{
+{thoenix-lib, ...}: {
   self,
   lib,
   flake-parts-lib,
@@ -61,9 +61,9 @@
 
         # builds the terranix configuration for each terraform configuration
         # and merges them into a single configuration derivation
-        finalConfigurations = inputs.thoenix.lib.buildTerraformConfigurations {
+        finalConfigurations = thoenix-lib.buildTerraformConfigurations {
           configDir = terraformConfigurationDirectory;
-          configNames = inputs.thoenix.lib.determineSubdirNames {
+          configNames = thoenix-lib.determineSubdirNames {
             path = terraformConfigurationDirectory;
           };
           terranixModules = cfg.terranixModules;

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,9 @@
     flake-parts,
     ...
   }:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+    flake-parts.lib.mkFlake {inherit inputs;} ({flake-parts-lib, ...}: let
+      inherit (flake-parts-lib) importApply;
+    in {
       systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
       imports = [
         ./lib.nix
@@ -58,8 +60,8 @@
           };
         };
 
-        flakeModule = ./flake-parts/flake-module.nix;
+        flakeModule = importApply ./flake-parts/flake-module.nix {thoenix-lib = self.lib;};
         customOutputModule = ./custom-outputs.nix;
       };
-    };
+    });
 }


### PR DESCRIPTION
This fixes a long-running issue with the module where `inputs` would refer to the consuming flake's inputs rather than thoenix's. By using `importApply` to create the module, we can pass in thoenix's `lib` output directly.

This means that consuming flakes will no longer have to have their `thoenix` input named `thoenix` and can name it as they choose.